### PR TITLE
fix: set color temp even when off, to have a smooth turn-on transition

### DIFF
--- a/components/adaptive_lighting/adaptive_lighting.h
+++ b/components/adaptive_lighting/adaptive_lighting.h
@@ -51,7 +51,6 @@ protected:
   float last_requested_color_temp_{0};
 
   void handle_light_state_change();
-  void handle_target_state_reached();
 };
 
 } // namespace adaptive_lighting


### PR DESCRIPTION
This pull request includes several changes to the `AdaptiveLightingComponent` class in the `components/adaptive_lighting/adaptive_lighting.cpp` and `components/adaptive_lighting/adaptive_lighting.h` files. The changes primarily focus on removing unnecessary methods, improving the handling of light state changes, and refining the update logic.

### Removal of Unnecessary Methods:
* Removed the `handle_target_state_reached` method and its callback registration in the `setup` method. [[1]](diffhunk://#diff-778f0eb287823f150f4e0be4c85715c21fd2be114d66ca185912756dc6e4302aL17) [[2]](diffhunk://#diff-5de47892bd1ce74d58470aa982adeac5c7116386520d9fdebb41a112c8bd6e3cL54)

### Handling of Light State Changes:
* Modified the `handle_light_state_change` method to handle the transition when the light is turned off and to enable adaptive lighting when the light turns back on if the restore mode is `SWITCH_ALWAYS_ON`.

### Update Logic Improvements:
* Removed the log message and early return when the light is off in the `update` method.
* Adjusted the condition to set the transition length only if the light is on in the `update` method.

### Miscellaneous:
* Removed a redundant call to `force_next_update` in the `write_state` method.
* Added the `override` keyword to the `dump_config` method declaration.