### PR TITLE
feat: add toolchain matrix dimension and fix ESP-IDF build errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,9 @@ jobs:
           - ${{ needs.esphome_version.outputs.tag }}
           - 2025.11.5
           - beta
-        esp32_board:
-          - esp32dev
-          - esp32-c3-devkitm-1
+        esp32_variant:
+          - esp32
+          - esp32c3
     container:
       image: ghcr.io/esphome/esphome:${{ matrix.esphome_version }}
       volumes:
@@ -56,10 +56,10 @@ jobs:
         with:
           cmd: yq -i '.external_components[0].source = "./components"' ${{ env.YAML_FILE }}
 
-      - name: Set esp32 board
+      - name: Set esp32 variant
         uses: mikefarah/yq@v4
         with:
-          cmd: yq -i '.esp32.board = "${{ matrix.esp32_board }}"' ${{ env.YAML_FILE }}
+          cmd: yq -i '.esp32.variant = "${{ matrix.esp32_variant }}"' ${{ env.YAML_FILE }}
 
       - name: Prepare secrets
         run: |-
@@ -78,7 +78,7 @@ jobs:
             ~/.cache/pip
             ~/.platformio/.cache
             ~/.platformio/packages
-          key: ${{ runner.os }}-pio-${{ env.ESPHOME_VER_HASH }}-${{ matrix.esp32_board }}
+          key: ${{ runner.os }}-pio-${{ env.ESPHOME_VER_HASH }}-${{ matrix.esp32_variant }}
 
       - name: Build
         run: esphome compile "$YAML_FILE"
@@ -86,7 +86,7 @@ jobs:
       - name: Add build summary
         if: always()
         run: |
-          echo "- **Device Name:** ${{ matrix.esp32_board }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Device Name:** ${{ matrix.esp32_variant }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Config File:** ${{ env.YAML_FILE }}" >> $GITHUB_STEP_SUMMARY
           echo "- **ESPHome Version:** ${{ env.ESPHOME_VERSION }}" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,12 @@ jobs:
         esp32_variant:
           - esp32
           - esp32c3
+        toolchain:
+          - platformio
+          - esp-idf
+        exclude:
+          - esphome_version: 2025.11.5
+            toolchain: esp-idf
     container:
       image: ghcr.io/esphome/esphome:${{ matrix.esphome_version }}
       volumes:
@@ -78,15 +84,18 @@ jobs:
             ~/.cache/pip
             ~/.platformio/.cache
             ~/.platformio/packages
-          key: ${{ runner.os }}-pio-${{ env.ESPHOME_VER_HASH }}-${{ matrix.esp32_variant }}
+          key: ${{ runner.os }}-pio-${{ env.ESPHOME_VER_HASH }}-${{ matrix.esp32_variant }}-${{ matrix.toolchain }}
 
       - name: Build
-        run: esphome compile "$YAML_FILE"
+        env:
+          TOOLCHAIN_FLAG: ${{ matrix.esphome_version != '2025.11.5' && format('--toolchain {0}', matrix.toolchain) || '' }}
+        run: esphome $TOOLCHAIN_FLAG compile "$YAML_FILE"
 
       - name: Add build summary
         if: always()
         run: |
           echo "- **Device Name:** ${{ matrix.esp32_variant }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Toolchain:** ${{ matrix.toolchain }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Config File:** ${{ env.YAML_FILE }}" >> $GITHUB_STEP_SUMMARY
           echo "- **ESPHome Version:** ${{ env.ESPHOME_VERSION }}" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,9 @@ jobs:
             ~/.cache/pip
             ~/.platformio/.cache
             ~/.platformio/packages
-          key: ${{ runner.os }}-pio-${{ env.ESPHOME_VER_HASH }}-${{ matrix.esp32_variant }}-${{ matrix.toolchain }}
+            ~/.esphome/idf/frameworks
+            ~/.esphome/idf/tools/cmake
+          key: ${{ runner.os }}-esphome-${{ env.ESPHOME_VER_HASH }}-${{ matrix.toolchain }}
 
       - name: Build
         env:

--- a/components/adaptive_lighting/adaptive_lighting.cpp
+++ b/components/adaptive_lighting/adaptive_lighting.cpp
@@ -1,6 +1,7 @@
 #include "adaptive_lighting.h"
 #include "adaptive_lighting_version.h"
 
+#include <cinttypes>
 #include <cmath>
 #include <utility>
 
@@ -15,6 +16,7 @@ namespace esphome::adaptive_lighting {
 class AdaptiveLightingListenerAdapter : public light::LightRemoteValuesListener {
 public:
   explicit AdaptiveLightingListenerAdapter(AdaptiveLightingComponent *parent) : parent_(parent) {}
+  virtual ~AdaptiveLightingListenerAdapter() = default;
   void on_light_remote_values_update() override { parent_->on_light_remote_values_update(); }
 
 private:
@@ -251,7 +253,7 @@ void AdaptiveLightingComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Adjusted   sunrise elevation: %.3f, sunset elevation: %.3f", sun_events.sunrise_elevation,
                 sun_events.sunset_elevation);
   ESP_LOGCONFIG(TAG, "Color temperature range: %.3f - %.3f", min_mireds_, max_mireds_);
-  ESP_LOGCONFIG(TAG, "Transition length: %d", transition_length_);
+  ESP_LOGCONFIG(TAG, "Transition length: %" PRIu32, transition_length_);
 
   for (int i = 0; i < 24; i++) {
     auto time = sun_events.today;

--- a/example_adaptive_lighting.yaml
+++ b/example_adaptive_lighting.yaml
@@ -9,7 +9,7 @@ external_components:
   - source: github://mdvorak/esphome-adaptive-lighting
 
 esp32:
-  board: esp32dev
+  variant: esp32
   framework:
     type: esp-idf
 


### PR DESCRIPTION
## Summary

- Adds `toolchain` (platformio / esp-idf) as a new build matrix dimension alongside `esp32_variant`
- Replaces `esp32.board` with `esp32.variant` in the build matrix and example config
- Fixes two ESP-IDF compiler errors: virtual destructor on `AdaptiveLightingListenerAdapter` and `PRIu32` format specifier for `uint32_t`

## Test plan

- [x] CI build passes for all matrix combinations (esp32/esp32c3 × platformio/esp-idf)
- [x] `2025.11.5` correctly excluded from esp-idf toolchain builds
- [x] No `-Werror=delete-non-virtual-dtor` or format-specifier warnings on esp-idf toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)